### PR TITLE
Check 3 optional properties

### DIFF
--- a/query.py
+++ b/query.py
@@ -320,10 +320,11 @@ if __name__ == '__main__':
                 format_supported_with_optimal_tiling_features(info.fmts, vk.Format.S8_UINT, ds_required_flags))
     add_rq('stencil8 <= 4 bytes', d24s8_or_s8)
 
-    # Additional requirements?
-
     add_min_opt_property('maxMemoryAllocationSize', 268435456)
     add_min_opt_property('maxBufferSize', 268435456)
+    # TODO(https://github.com/gpuweb/gpuweb/issues/4270): remove or update this based on the conclusion there
     add_min_opt_property('maxPerSetDescriptors', 700)
+    
+    # Additional requirements?
 
     run(requirements)

--- a/query.py
+++ b/query.py
@@ -88,6 +88,15 @@ def run(requirements):
                     info.features.add(v['name'])
         info.limits = report['properties']['limits']
 
+        info.properties = {}
+        for core1x in report:
+            if core1x.startswith('core1') and 'properties' in report[core1x]:
+                for k, v in report[core1x]['properties'].items():
+                    info.properties[k] = v
+        if 'extended' in report and 'deviceproperties2' in report['extended']:
+            for v in report['extended']['deviceproperties2']:
+                info.properties[v['name']] = v['value']
+
         # +  ' ' + report['properties']['driverVersionText']
         deviceName = report['properties']['deviceName']
         deviceName = re.sub(r' \((LLVM|ACO|Subzero).*?\)', '', deviceName)
@@ -188,6 +197,10 @@ if __name__ == '__main__':
     def add_bits_limit(name, bits):
         add_rq('{} has bits 0b{:b}'.format(name, bits),
                lambda info: (info.limits[name] & bits) == bits)
+
+    def add_min_opt_property(name, value):
+        add_rq('{} >= {}'.format(name, value),
+               lambda info: (name not in info.properties) or int(info.properties[name]) >= value)
 
     # Known requirements
 
@@ -308,5 +321,9 @@ if __name__ == '__main__':
     add_rq('stencil8 <= 4 bytes', d24s8_or_s8)
 
     # Additional requirements?
+
+    add_min_opt_property('maxMemoryAllocationSize', 268435456)
+    add_min_opt_property('maxBufferSize', 268435456)
+    add_min_opt_property('maxPerSetDescriptors', 700)
 
     run(requirements)


### PR DESCRIPTION
- `maxMemoryAllocationSize` & `maxBufferSize` map to WebGPU's `maxBufferSize` (only partially loses 2 devices)
- `maxPerSetDescriptors` maps to WebGPU's `maxBindingsPerBindGroup` (set it to 700 instead of 1000 or else we are losing devices)

I will open an issue on the spec repo to lower the limit to at least 700 by default.

```
Requirement "maxPerSetDescriptors >= 1000" loses 38 (and partially loses 14) further deviceNames:
  In ALL reports (38 deviceNames):
    x AMD Radeon HD - FirePro D300: 2 (7598 10450)
    x AMD Radeon Pro 455: 1 (19237)
    x AMD Radeon Pro 5500 XT: 1 (19703)
    x AMD Radeon Pro 5500M: 6 (12173 17321 18370 18402 18876 19496)
    x AMD Radeon Pro 555: 2 (19182 19721)
    x AMD Radeon Pro 555X: 5 (12248 12834 13632 18849 18851)
    x AMD Radeon Pro 560: 3 (16847 17783 18667)
    x AMD Radeon Pro 560X: 4 (16782 16995 17003 18525)
    x AMD Radeon Pro 570: 1 (18186)
    x AMD Radeon Pro Vega 20: 2 (16905 17497)
    x AMD Radeon Pro Vega 48: 1 (18502)
    x AMD Radeon Pro Vega 56: 1 (16451)
    x AMD Radeon Pro W5700X: 1 (18292)
    x AMD Radeon RX 570: 1 (17293)
    x AMD Radeon RX 580: 2 (11047 18921)
    x Apple M1 Pro: 13 (13606 14001 16934 16989 17277 17872 18152 18537 18565 18691 18749 18975 19041)
    x Apple M1 Ultra: 4 (17092 17381 17879 18338)
    x Apple M2: 9 (16915 17860 17895 18216 18787 19113 19223 19464 19510)
    x Apple M2 Max: 1 (18789)
    x Apple M2 Pro: 1 (19130)
    x Intel HD Graphics 4000: 2 (9638 18923)
    x Intel HD Graphics 5000: 1 (16388)
    x Intel Iris Graphics: 2 (9665 19397)
    x Intel Iris Pro Graphics: 12 (7063 9812 9814 9816 11362 11481 12653 13573 14151 17044 17590 17778)
    x Intel(R) HD Graphics 5300: 1 (19258)
    x Intel(R) Iris(TM) Graphics 6000: 4 (11332 18448 18725 19301)
    x Intel(R) Iris(TM) Graphics 6100: 4 (17664 17687 18406 19067)
    x Intel(R) Iris(TM) Plus Graphics: 7 (11877 13745 17065 17132 17350 18611 19575)
    x Intel(R) Iris(TM) Plus Graphics 650: 1 (16944)
    x Intel(R) Iris(TM) Plus Graphics 655: 1 (19338)
    x Intel(R) Iris(TM) Pro Graphics 6200: 2 (18412 19257)
    x Intel(R) SKL Unknown: 1 (11305)
    x NVIDIA GeForce GT 640M: 1 (19121)
    x NVIDIA GeForce GT 650M: 1 (9637)
    x NVIDIA GeForce GT 750M: 9 (7062 9811 9813 9815 17043 17768 18304 18632 19335)
    x NVIDIA GeForce GTX 680MX: 1 (17144)
    x NVIDIA GeForce GTX 775M: 1 (18842)
    x NVIDIA Quadro K4200: 1 (10583)
  In SOME reports (14 deviceNames):
    ~ AMD Radeon Pro 5300M: 7 of 9 (10103 12130 13339 17089 18227 18809 19516; ok: 10099 13860)
    ~ AMD Radeon Pro 5600M: 1 of 3 (10322; ok: 14700 18056)
    ~ AMD Radeon Pro 580X: 1 of 2 (19109; ok: 10495)
    ~ AMD Radeon RX 6600: 2 of 11 (18663 19345; ok: 12796 13253 14295 14943 15928 17339 17513 19296 19530)
    ~ AMD Radeon RX 6800 XT: 1 of 21 (18291; ok: 10010 10710 11111 11563 11990 12279 12889 13194 13613 14095 15060 15613 16040 16352 16880 17741 18043 18512 18661 19171)
    ~ AMD Radeon RX 6900 XT: 2 of 60 (13265 15154; ok: 10222 10549 11100 11102 11149 11150 11152 11185 11204 11321 11738 11770 11771 11792 11941 11986 12013 12165 12166 12273 12298 12404 12481 12482 12509 13241 13302 13304 13759 13893 14417 14418 15089 15090 15267 15289 15290 15747 15764 15767 15776 15800 15827 16104 16251 16326 16333 16505 16792 17058 17900 17902 18371 19169 19393 19419 19669 19670)
    ~ AMD Radeon RX Vega 64: 16 of 18 (9626 9630 9646 10079 10245 11293 11294 12289 13161 14191 14837 15034 15539 15540 16135 18263; ok: 5659 6898)
    ~ Apple M1: 39 of 45 (11048 11395 11396 11632 11689 11884 12086 13000 13410 13597 14080 14169 14584 14630 14927 15137 15250 15281 15337 15338 15517 16446 16632 16832 16913 17007 17148 17150 18000 18072 18656 18733 18784 18934 19110 19135 19198 19503 19606; ok: 15518 15671 15750 15791 15937 16158)
    ~ Apple M1 Max: 19 of 21 (13018 14522 14673 14752 15018 16557 16663 16843 16914 17767 17845 18302 18340 18407 18624 18895 18971 19317 19632; ok: 15815 16220)
    ~ Intel(R) HD Graphics 630: 2 of 81 (17784 18668; ok: 2074 2145 2482 2514 2519 2963 3117 3284 3389 3669 3955 4202 4268 4465 4478 4655 5015 5169 5423 5453 5583 5781 5883 6156 6221 6371 6614 6673 6795 6874 6933 7091 7183 7229 7303 7350 7439 7521 7609 7734 7797 8344 8525 8596 8700 8817 8982 9253 9330 9364 9508 9678 9740 9793 10151 10280 10356 10615 10794 11412 11414 11587 12156 12389 13044 14077 14286 14772 14840 15263 15692 16053 16237 16644 17048 17360 18529 18538 19057)
    ~ Intel(R) Iris(TM) Plus Graphics 640: 6 of 7 (13263 13264 13266 13756 15516 17618; ok: 1732)
    ~ Intel(R) Iris(TM) Plus Graphics 645: 3 of 4 (13596 17555 18861; ok: 15806)
    ~ Intel(R) UHD Graphics 630: 12 of 127 (9003 12249 12835 16783 16996 17880 18286 18401 18810 18850 18877 19497; ok: 2796 3114 3168 3346 3744 3817 4385 4513 4686 4890 4919 5285 5639 6022 6050 6181 6187 6543 6601 6649 6811 6923 6991 7024 7092 7185 7298 7518 7748 7956 8100 8267 8569 8580 8586 8619 8792 8857 8984 9204 9322 9406 9420 9440 9458 9465 9578 9601 9732 9839 10081 10096 10165 10227 10257 10388 10745 11153 11622 11817 11913 11925 12149 12433 12597 12657 12670 12711 12762 12848 12975 13029 13067 13252 13407 13417 13576 14040 14127 14398 14427 14591 14605 14712 14968 15125 15297 15345 15562 15564 15712 15939 16164 16378 16721 16770 16811 16856 17175 17456 17634 17679 17685 17765 18095 18181 18184 18414 18508 18728 19090 19253 19387 19437 19547)
    ~ NVIDIA GeForce GTX 650: 1 of 6 (13744; ok: 12672 13735 14895 16018 18001)
```