### PR TITLE
Remove allowance for VK_AMD_negative_viewport_height

### DIFF
--- a/query.py
+++ b/query.py
@@ -336,10 +336,9 @@ if __name__ == '__main__':
            lambda info: 'textureCompressionBC' in info.features or
            ('textureCompressionETC2' in info.features and 'textureCompressionASTC_LDR' in info.features))
 
-    add_rq('viewport Y-flip: Vulkan 1.1 or VK_KHR_maintenance1 or VK_AMD_negative_viewport_height',
+    add_rq('viewport Y-flip: Vulkan 1.1 or VK_KHR_maintenance1',
            lambda info: info.apiVersion >= (1, 1, 0) or
-           'VK_KHR_maintenance1' in info.extensions or
-           'VK_AMD_negative_viewport_height' in info.extensions)
+           'VK_KHR_maintenance1' in info.extensions)
 
     # Texture formats
 

--- a/query.py
+++ b/query.py
@@ -336,7 +336,7 @@ if __name__ == '__main__':
            lambda info: 'textureCompressionBC' in info.features or
            ('textureCompressionETC2' in info.features and 'textureCompressionASTC_LDR' in info.features))
 
-    add_rq('viewport Y-flip: Vulkan 1.1 or VK_KHR_maintenance1',
+    add_rq('Vulkan 1.1 or VK_KHR_maintenance1',
            lambda info: info.apiVersion >= (1, 1, 0) or
            'VK_KHR_maintenance1' in info.extensions)
 


### PR DESCRIPTION
Per https://github.com/gpuweb/gpuweb/issues/1069 we no longer support any Vulkan 1.0 devices without VK_KHR_maintenance1.