### PR TITLE
Require `maxVertexOutputComponents` & `maxFragmentInputComponents` to be at least 68

### DIFF
--- a/query.py
+++ b/query.py
@@ -277,8 +277,8 @@ if __name__ == '__main__':
     add_min_limit('maxVertexInputBindingStride', 2048)
     add_min_limit('maxVertexInputAttributeOffset', 2047)
 
-    add_min_limit('maxVertexOutputComponents', 64)
-    add_min_limit('maxFragmentInputComponents', 64)
+    add_min_limit('maxVertexOutputComponents', 68)
+    add_min_limit('maxFragmentInputComponents', 68)
     add_min_limit('maxComputeSharedMemorySize', 16384)
     add_min_limit('maxComputeWorkGroupInvocations', 256)
     add_rq('maxComputeWorkGroupSize >= [256,256,64]',


### PR DESCRIPTION
https://github.com/gpuweb/gpuweb/issues/1962#issuecomment-1966619852